### PR TITLE
Reproduce MDC context propagation issue with an external health endpoint

### DIFF
--- a/mdc-propagation/src/main/java/org/acme/external/HealthEndpoint.java
+++ b/mdc-propagation/src/main/java/org/acme/external/HealthEndpoint.java
@@ -1,0 +1,22 @@
+package org.acme.external;
+
+import io.smallrye.health.SmallRyeHealthReporter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.MDC;
+
+@Path("/health")
+@ApplicationScoped
+public class HealthEndpoint {
+  @Inject
+  SmallRyeHealthReporter smallRyeHealthReporter;
+
+  @GET
+  public Response health() {
+    MDC.put("class", "HealthEndpoint");
+    return Response.ok(smallRyeHealthReporter.getHealth().getPayload().toString()).build();
+  }
+}

--- a/mdc-propagation/src/test/java/org/acme/MDCLoggingWithExternalHealthEndpointTest.java
+++ b/mdc-propagation/src/test/java/org/acme/MDCLoggingWithExternalHealthEndpointTest.java
@@ -1,0 +1,30 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.RepeatedTest;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+public class MDCLoggingWithExternalHealthEndpointTest {
+
+  @Inject
+  InMemoryLogHandler inMemoryLogHandler;
+  @Inject
+  InMemoryLogHandlerProducer producer;
+
+  @RepeatedTest(10)
+  void testMDCLoggingWithExternalHealthEndpoint() {
+    InMemoryLogHandler.reset();
+
+    given().get("/health").then().statusCode(200);
+
+    assertThat(inMemoryLogHandler.logRecords())
+        .hasSize(4)
+        .anyMatch(record -> record.contains("health-check=TestHC"))
+        .anyMatch(record -> record.contains("health-check=TestHC2"))
+        .anyMatch(record -> record.contains("health-check=AsyncTestHC"))
+        .anyMatch(record -> record.contains("health-check=AsyncTestHC2"));
+  }
+}


### PR DESCRIPTION
A follow-up on https://github.com/quarkusio/quarkus/discussions/47481

When adding the `MDC.put("class", "HealthEndpoint")` in the custom health check endpoint, instead of using `/q/health`, the context propagation's behaviour seems non-deterministic.